### PR TITLE
Support multiple Ports for ADD_ONION command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ package manager).
 const tor = require('granax')();
 
 tor.on('ready', function() {
-  tor.createHiddenService('127.0.0.1:8080', (err, result) => {
+  tor.createHiddenService([{target: '127.0.0.1:8080'}], (err, result) => {
     console.info(`Service URL: ${result.serviceId}.onion`);
     console.info(`Private Key: ${result.privateKey}`);
   });

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ package manager).
 const tor = require('granax')();
 
 tor.on('ready', function() {
-  tor.createHiddenService([{target: '127.0.0.1:8080'}], (err, result) => {
+  tor.createHiddenService('127.0.0.1:8080', (err, result) => {
     console.info(`Service URL: ${result.serviceId}.onion`);
     console.info(`Private Key: ${result.privateKey}`);
   });

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -32,11 +32,35 @@ exports.PROTOCOLINFO = function() {
 };
 
 /**
- * @param {string} target - Address:Port string
+ * @param {array} ports
+ * @param {array} command
+ */
+const _addOnionPortsToCommand = function(ports, command) {
+  const defaultVirtualPort = 80;
+  if (!ports.length) {
+    command.push(`Port=${defaultVirtualPort}`);
+    return;
+  }
+
+  for (let port of ports) {
+    let _portsString
+    if (port.virtualPort) {
+      _portsString = `Port=${port.virtualPort}`;
+    } else {
+      _portsString = `Port=${defaultVirtualPort}`;
+    }
+    if (port.target) {
+      _portsString += `,${port.target}`;
+    }
+    command.push(_portsString);
+  }
+}
+
+/**
+ * @param {array} ports - Array containing optional virtualPort (defaults to 80) and target ip:port string
  * @param {object} [options]
  * @param {string} [options.clientName] - Client auth identifier
  * @param {string} [options.clientBlob] - Arbitrary auth data
- * @param {number} [options.virtualPort=80] - Virtual port for the service
  * @param {string} [options.keyType="NEW"] - Create a new key or use RSA1024
  * @param {string} [options.keyBlob="BEST"] - Key type to create or serialized
  * @param {boolean} [options.discardPrivateKey=false] - Do not return key
@@ -44,11 +68,10 @@ exports.PROTOCOLINFO = function() {
  * @param {boolean} [options.basicAuth=false] - Use client name and blob auth
  * @param {boolean} [options.nonAnonymous=false] - Non-anononymous mode
  */
-exports.ADD_ONION = function(target, opts = {}) {
+exports.ADD_ONION = function(ports, opts = {}) {
   let options = merge({
     clientName: null,
     clientBlob: null,
-    virtualPort: 80,
     keyType: 'NEW',
     keyBlob: 'BEST',
     discardPrivateKey: false,
@@ -75,7 +98,7 @@ exports.ADD_ONION = function(target, opts = {}) {
     command.push('Flags=' + flags.join(','));
   }
 
-  command.push(`Port=${options.virtualPort},${target}`);
+  _addOnionPortsToCommand(ports, command);
 
   if (options.clientName && options.clientBlob) {
     command.push(`ClientAuth=${options.clientName}:${options.clientBlob}`);

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -31,14 +31,32 @@ exports.PROTOCOLINFO = function() {
   return 'PROTOCOLINFO';
 };
 
+const defaultOnionVirtualPort = 80;
 /**
  * @param {array} ports
+ * @param {object} options
  * @param {array} command
  */
-const _addOnionPortsToCommand = function(ports, command) {
-  const defaultVirtualPort = 80;
+const _addOnionPortsStringToCommand = function(ports, opts, command) {
+  if (opts.virtualPort) {
+    command.push(`Port=${opts.virtualPort},${ports}`);
+  } else {
+    command.push(`Port=${defaultOnionVirtualPort},${ports}`);
+  }
+}
+
+/**
+ * @param {array} ports
+ * @param {object} options
+ * @param {array} command
+ */
+const _addOnionPortsToCommand = function(ports, opts, command) {
+  if (typeof ports === 'string') {
+    _addOnionPortsStringToCommand(ports, opts, command);
+    return;
+  }
   if (!ports.length) {
-    command.push(`Port=${defaultVirtualPort}`);
+    command.push(`Port=${defaultOnionVirtualPort}`);
     return;
   }
 
@@ -47,7 +65,7 @@ const _addOnionPortsToCommand = function(ports, command) {
     if (port.virtualPort) {
       _portsString = `Port=${port.virtualPort}`;
     } else {
-      _portsString = `Port=${defaultVirtualPort}`;
+      _portsString = `Port=${defaultOnionVirtualPort}`;
     }
     if (port.target) {
       _portsString += `,${port.target}`;
@@ -98,7 +116,7 @@ exports.ADD_ONION = function(ports, opts = {}) {
     command.push('Flags=' + flags.join(','));
   }
 
-  _addOnionPortsToCommand(ports, command);
+  _addOnionPortsToCommand(ports, opts, command);
 
   if (options.clientName && options.clientBlob) {
     command.push(`ClientAuth=${options.clientName}:${options.clientBlob}`);

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -293,18 +293,18 @@ class TorController extends EventEmitter {
 
   /**
    * Establishes a hidden service on the given target
-   * @param {string} target - The target ip:port string
+   * @param {array} ports - Array containing optional virtualPort (defaults to 80) and target ip:port string
    * @param {object} [options] - {@link module:commands#ADD_ONION}
    * @param {TorController~createHiddenServiceCallback} callback
    */
-  createHiddenService(target, options, callback) {
+  createHiddenService(ports, options, callback) {
     /* istanbul ignore if */
     if (typeof options === 'function') {
       callback = options;
       options = {};
     }
 
-    this._send(commands.ADD_ONION(target, options), callback);
+    this._send(commands.ADD_ONION(ports, options), callback);
   }
   /**
    * @callback TorController~createHiddenServiceCallback

--- a/test/commands.unit.js
+++ b/test/commands.unit.js
@@ -37,7 +37,7 @@ describe('@module:granax/commands', function() {
   describe('ADD_ONION', function() {
 
     it('should return add onion message with basic auth', function() {
-      expect(commands.ADD_ONION('127.0.0.1:8080', {
+      expect(commands.ADD_ONION([{target: '127.0.0.1:8080'}], {
         clientName: 'user',
         clientBlob: 'pass',
         basicAuth: true
@@ -48,8 +48,30 @@ describe('@module:granax/commands', function() {
     });
 
     it('should return add onion message', function() {
-      expect(commands.ADD_ONION('127.0.0.1:8080')).to.equal(
+      expect(commands.ADD_ONION([{target: '127.0.0.1:8080'}])).to.equal(
         'ADD_ONION NEW:BEST Port=80,127.0.0.1:8080'
+      );
+    });
+
+    it('should return add onion message with multiple ports', function() {
+      const ports = [
+        {target: '127.0.0.1:8080'},
+        {virtualPort: 8070, target: '127.0.0.1:8090'}
+      ];
+      expect(commands.ADD_ONION(ports)).to.equal(
+        'ADD_ONION NEW:BEST Port=80,127.0.0.1:8080 Port=8070,127.0.0.1:8090'
+      );
+    });
+
+    it('should return add onion message with given single port', function() {
+      expect(commands.ADD_ONION([{virtualPort: 8080}])).to.equal(
+        'ADD_ONION NEW:BEST Port=8080'
+      );
+    });
+
+    it('should return add onion message with default port', function() {
+      expect(commands.ADD_ONION([])).to.equal(
+        'ADD_ONION NEW:BEST Port=80'
       );
     });
 

--- a/test/commands.unit.js
+++ b/test/commands.unit.js
@@ -75,6 +75,23 @@ describe('@module:granax/commands', function() {
       );
     });
 
+    describe('ports as string and virtualport in options', function() {
+
+      it('should return add onion message', function() {
+        expect(commands.ADD_ONION('127.0.0.1:8080')).to.equal(
+          'ADD_ONION NEW:BEST Port=80,127.0.0.1:8080'
+        );
+      });
+
+      it('should return add onion message with correct vport', function() {
+        expect(commands.ADD_ONION('127.0.0.1:8080',
+                                  {virtualPort: 8080})).to.equal(
+          'ADD_ONION NEW:BEST Port=8080,127.0.0.1:8080'
+        );
+      });
+
+    })
+
   });
 
   describe('DEL_ONION', function() {


### PR DESCRIPTION
Hey, thanks for your work, it's really helpful.

While working with kad-onion and granax I stumbled over the fact that it's not possible to specify multiple ports when calling createHiddenService, so I added it and thought I'll open this PR. If there's something missing, wrong or if you wish to see something changed in this PR, please let me know and I'll try to fix it.

Best regards

Edit: It would of course be possible to check if `ports` is a string and convert it to a fitting array to keep backwards compatibility